### PR TITLE
make rollout_iterations and lead_time_hours params in module

### DIFF
--- a/docs/archesweather/eval.md
+++ b/docs/archesweather/eval.md
@@ -2,7 +2,7 @@
 
 Set model run name (used in hydra argument `++name=NAME`): 
 ```sh
-NAME=archesweathergen
+MODEL=archesweathergen
 ```
 
 ## Commands to compute metrics
@@ -10,8 +10,8 @@ NAME=archesweathergen
 ### Rank histogram
 ```sh
 python -m geoarches.evaluation.eval_multistep  \
---pred_path evalstore/${NAME}/ \
---output_dir evalstore/${NAME}_metrics/ \
+--pred_path evalstore/${MODEL}/ \
+--output_dir evalstore/${MODEL}_metrics/ \
 --groundtruth_path data/era5_240/full/ \
 --multistep 10 --num_workers 4 \
 --metrics era5_rank_histogram_50_members
@@ -22,7 +22,7 @@ python -m geoarches.evaluation.eval_multistep  \
 ### Rank histogram
 ```sh
 python -m geoarches.evaluation.plot --output_dir plots/ 
---metric_paths evalstore/${NAME}_metrics/test-multistep=10-era5_rank_histogram_50_members.nc 
+--metric_paths evalstore/${MODEL}_metrics/test-multistep=10-era5_rank_histogram_50_members.nc
 --model_names ArchesWeatherGen \
 --model_colors red \
 --metrics rankhist \

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -1,0 +1,64 @@
+# Integration testing
+
+Since we do not have CI/CD pipeline set up for integration testing, here are some recommended commands to run and try out before submitting a pull request:
+
+## Test 1: deterministic forecast module
+
+### Train
+
+```sh
+python -m geoarches.main_hydra \
+module=archesweather dataloader=era5 ++name=test_deterministic \
+++log=True ++cluster.wandb_mode=online \
+limit_train_batches=200 limit_val_batches=200 save_step_frequency=100 \
+max_steps=1200
+```
+
+Checks:
+- metrics are logged and look decent on Wandb.
+- checkpoint and config dumped to `modelstore/test_deterministic/`.
+
+### Evaluate
+
+```sh
+HYDRA_FULL_ERROR=1 python -m geoarches.main_hydra \
+++name=test_deterministic \
+mode=test \
+++module.inference.save_test_outputs=True \
+++module.inference.rollout_iterations=10 \
+++dataloader.test_args.multistep=10 \
+++limit_test_batches=0.1
+```
+
+Checks:
+- predictions and metrics are dumped to `evalstore/test_deterministic/`.
+
+## Test 2: diffusion module
+
+### Train
+```sh
+HYDRA_FULL_ERROR=1 python -m geoarches.main_hydra \
+module=archesweathergen dataloader=era5 ++name=test_diffusion \
+++module.module.load_deterministic_model=[archesweather-m-seed0,archesweather-m-seed1,archesweather-m-skip-seed0,archesweather-m-skip-seed1] \
+++log=True ++cluster.wandb_mode=online \
+++limit_train_batches=200 ++limit_val_batches=200 save_step_frequency=100
+```
+
+Checks:
+- metrics are logged and look decent on Wandb.
+- checkpoint and config dumped to `modelstore/test_diffusion/`.
+
+### Evaluate
+
+```sh
+HYDRA_FULL_ERROR=1 python -m geoarches.main_hydra \
+++name=test_diffusion \
+mode=test \
+++module.inference.save_test_outputs=True \
+++module.inference.rollout_iterations=10 \
+++dataloader.test_args.multistep=10 \
+++limit_test_batches=0.1
+```
+
+Checks:
+- predictions and metrics are dumped to `evalstore/test_diffusion/`.

--- a/docs/user_guide/args.md
+++ b/docs/user_guide/args.md
@@ -22,7 +22,6 @@ The two arguments you absolutely should know are:
 | `limit_train_batches`<br/>`limit_val_batches`<br/>`limit_test_batches` | Optional. | Limit batches loaded in dataloaders in [Lightning API](https://lightning.ai/docs/pytorch/stable/common/trainer.html#limit-train-batches). |
 | `log_freq`                     | 100                  | Frequency to log metrics. |
 | `max_steps`                    | 300000               | Max steps to run training. |
-| `save_step_frequency`          | 50000                | Save checkpoint every N steps. |
 | `seed`                         | 0                    | Seed lightning with `L.seed_everything(cfg.seed)` |
 
 ## Args to save and load checkpoints
@@ -34,7 +33,7 @@ The two arguments you absolutely should know are:
 | `resume`                       | `True`               | Set `True` to resume training from a checkpoint when mode=`train`. |
 | `ckpt_filename_match`          | Optional             | Set to substring to match checkpoints files under `exp_dir`/checkpoints/ if resuming checkpoint to train or running evaluation. Pipeline will choose latest checkpoint under `exp_dir/checkpoints/` that contains the substring `ckpt_filename_match`. |
 | `load_ckpt`                    | Optional             | Path to load Pytorch lightning module checkpoint from but not resume run. Not compatible with `ckpt_filename_match`. Will load checkpoint, but not resume training. |
-
+| `save_step_frequency`          | 50000                | Save checkpoint every N steps. |
 ## Logging args
 
 Currently only supports logging to WandB. See [User Guide](../user_guide/index.md#weights-and-biases-wandb) for more info.

--- a/geoarches/configs/dataloader/era5.yaml
+++ b/geoarches/configs/dataloader/era5.yaml
@@ -1,12 +1,13 @@
 dataset: 
   _target_: geoarches.dataloaders.era5.Era5Forecast
   path: data/era5_240/full/
-  lead_time_hours: 24 # mixed
+  lead_time_hours: 24
+  multistep: ${oc.select:module.rollout_iterations,1}
   norm_scheme: pangu
   load_prev: True
 
 validation_args:
-  multistep: 2
+  multistep: ${oc.select:module.validation.rollout_iterations,1}
 
 test_args:
-  multistep: 2
+  multistep: ${module.inference.rollout_iterations}

--- a/geoarches/configs/dataloader/era5.yaml
+++ b/geoarches/configs/dataloader/era5.yaml
@@ -2,12 +2,14 @@ dataset:
   _target_: geoarches.dataloaders.era5.Era5Forecast
   path: data/era5_240/full/
   lead_time_hours: 24
-  multistep: ${oc.select:module.rollout_iterations,1}
+  multistep: ${oc.select:module.train.rollout_iterations,1}
   norm_scheme: pangu
   load_prev: True
 
 validation_args:
-  multistep: ${oc.select:module.validation.rollout_iterations,1}
+  multistep: ${oc.select:module.val.rollout_iterations,1}
+  domain: val
 
 test_args:
-  multistep: ${module.inference.rollout_iterations}
+  multistep: ${oc.select:module.inference.rollout_iterations,1}
+  domain: test_z0012

--- a/geoarches/configs/dataloader/era5pred.yaml
+++ b/geoarches/configs/dataloader/era5pred.yaml
@@ -9,6 +9,8 @@ dataset:
 
 validation_args:
   multistep: 2
+  domain: val
 
 test_args:
   multistep: 2
+  domain: test_z0012

--- a/geoarches/configs/module/archesweather.yaml
+++ b/geoarches/configs/module/archesweather.yaml
@@ -11,14 +11,28 @@ module:
   use_graphcast_coeffs: True
   use_prev: True
   loss_delta_normalization: True
-  lead_time_hours: ${dataloader.dataset.lead_time_hours}
-  rollout_iterations: 1
 
-validation:
-  rollout_iterations: 1 # number of rollouts/multistep
+defaults:
+  - metrics:  # Read from module/metrics/ folder.
+    - era5_deterministic
+
+train:
+  rollout_iterations: 1 # number of rollouts to compute loss on
+  metrics: ${oc.dict.values:module.metrics}  # list of default metrics from above.
+  metrics_kwargs:
+    rollout_iterations: 1 # number of rollouts to compute metrics on
+
+val:
+  rollout_iterations: 1 # number of rollouts to compute loss on
+  metrics: ${oc.dict.values:module.metrics}
+  metrics_kwargs:
+    rollout_iterations: 1 # number of rollouts to compute metrics on
 
 inference:
-  rollout_iterations: 1 # number of rollouts/multistep
+  rollout_iterations: 2  # number of rollouts to run inference on.
+  metrics: ${module.metrics}
+  metrics_kwargs:
+    rollout_iterations: ${..rollout_iterations}
 
 backbone:
   # default backbone

--- a/geoarches/configs/module/archesweather.yaml
+++ b/geoarches/configs/module/archesweather.yaml
@@ -11,6 +11,14 @@ module:
   use_graphcast_coeffs: True
   use_prev: True
   loss_delta_normalization: True
+  lead_time_hours: ${dataloader.dataset.lead_time_hours}
+  rollout_iterations: 1
+
+validation:
+  rollout_iterations: 1 # number of rollouts/multistep
+
+inference:
+  rollout_iterations: 1 # number of rollouts/multistep
 
 backbone:
   # default backbone

--- a/geoarches/configs/module/archesweathergen.yaml
+++ b/geoarches/configs/module/archesweathergen.yaml
@@ -33,10 +33,18 @@ module:
   num_warmup_steps: 5000
   num_training_steps: ${max_steps}
 
+  # for logging metrics
+  lead_time_hours: ${dataloader.dataset.lead_time_hours}
+  rollout_iterations: 1 # For training, number of rollouts
+
+validation:
+  num_members: 5
+  rollout_iterations: 1 # number of rollouts/multistep
+
 inference:
   num_steps: 25
   num_members: 10
-  rollout_iterations: 10 # number of rollouts
+  rollout_iterations: 10 # number of rollouts/multistep
   cf_guidance: 1
   s_churn: 0.0
   save_test_outputs: False

--- a/geoarches/configs/module/archesweathergen.yaml
+++ b/geoarches/configs/module/archesweathergen.yaml
@@ -1,7 +1,7 @@
 project: atmo-diffusion
 
 module:
-  _target_: lightning_modules.diffusion.DiffusionModule
+  _target_: geoarches.lightning_modules.diffusion.DiffusionModule
   name: ${name}
   cond_dim: 256
 
@@ -33,13 +33,18 @@ module:
   num_warmup_steps: 5000
   num_training_steps: ${max_steps}
 
-  # for logging metrics
-  lead_time_hours: ${dataloader.dataset.lead_time_hours}
-  rollout_iterations: 1 # For training, number of rollouts
+defaults:
+  - metrics:  # Read from module/metrics/ folder.
+    - era5_ensemble
+    - era5_brier
 
-validation:
+val:
   num_members: 5
-  rollout_iterations: 1 # number of rollouts/multistep
+  rollout_iterations: 2 # number of rollouts/multistep
+  metrics: ${oc.dict.values:module.metrics} # list of default metrics from above.
+  metrics_kwargs:
+    rollout_iterations: 1
+    save_memory: False # Set to True if memory constraints (ie. if num_members is big).
 
 inference:
   num_steps: 25
@@ -48,6 +53,10 @@ inference:
   cf_guidance: 1
   s_churn: 0.0
   save_test_outputs: False
+  metrics: ${module.metrics} # list of default metrics from above.
+  metrics_kwargs:
+    rollout_iterations: ${..rollout_iterations}
+    save_memory: False # Set to True if memory constraints (ie. if num_members is big).
 
 backbone:
   # default backbone

--- a/geoarches/configs/module/metrics/era5_brier.yaml
+++ b/geoarches/configs/module/metrics/era5_brier.yaml
@@ -1,0 +1,3 @@
+era5_brier_metric:
+  _target_: geoarches.metrics.brier_skill_score.Era5BrierSkillScore
+  lead_time_hours: ${dataloader.dataset.lead_time_hours}

--- a/geoarches/configs/module/metrics/era5_deterministic.yaml
+++ b/geoarches/configs/module/metrics/era5_deterministic.yaml
@@ -1,0 +1,3 @@
+era5_deterministic_metrics:
+  _target_: geoarches.metrics.deterministic_metrics.Era5DeterministicMetrics
+  lead_time_hours: ${dataloader.dataset.lead_time_hours}

--- a/geoarches/configs/module/metrics/era5_ensemble.yaml
+++ b/geoarches/configs/module/metrics/era5_ensemble.yaml
@@ -1,0 +1,3 @@
+era5_ensemble_metrics:
+  _target_: geoarches.metrics.ensemble_metrics.Era5EnsembleMetrics
+  lead_time_hours: ${dataloader.dataset.lead_time_hours}

--- a/geoarches/evaluation/eval_multistep.py
+++ b/geoarches/evaluation/eval_multistep.py
@@ -169,6 +169,8 @@ def main():
 
     # Predictions.
     def _pred_filename_filter(filename):
+        if "metric" in filename:
+            return False
         for substring in args.pred_filename_filter:
             if substring not in filename:
                 return False

--- a/geoarches/lightning_modules/diffusion.py
+++ b/geoarches/lightning_modules/diffusion.py
@@ -53,6 +53,7 @@ class DiffusionModule(BaseLightningModule):
         num_cycles=0.5,
         learn_residual=False,
         sd3_timestep_sampling=True,
+        lead_time_hours=24,
         **kwargs,
     ):
         """
@@ -93,9 +94,11 @@ class DiffusionModule(BaseLightningModule):
 
         # set up metrics
         save_memory = cfg.inference.num_members > 10
-        val_kwargs = dict(lead_time_hours=24, rollout_iterations=1, save_memory=save_memory)
+        val_kwargs = dict(
+            lead_time_hours=lead_time_hours, rollout_iterations=1, save_memory=save_memory
+        )
         test_kwargs = dict(
-            lead_time_hours=24,
+            lead_time_hours=lead_time_hours,
             rollout_iterations=cfg.inference.rollout_iterations,
             save_memory=save_memory,
         )
@@ -380,8 +383,8 @@ class DiffusionModule(BaseLightningModule):
 
     def validation_step(self, batch, batch_nb):
         # for the validation, we make some generations and log them
-        val_num_members = 5
-        val_rollout_iterations = 2
+        val_num_members = self.cfg.validation.num_steps
+        val_rollout_iterations = self.cfg.validation.rollout_iterations
         samples = [
             self.sample_rollout(
                 batch,

--- a/geoarches/lightning_modules/forecast.py
+++ b/geoarches/lightning_modules/forecast.py
@@ -11,7 +11,6 @@ from hydra.utils import instantiate
 from tensordict.tensordict import TensorDict
 
 from geoarches.dataloaders import era5, zarr
-from geoarches.metrics.deterministic_metrics import Era5DeterministicMetrics
 from geoarches.metrics.metric_base import compute_lat_weights, compute_lat_weights_weatherbench
 
 from .. import stats as geoarches_stats
@@ -93,15 +92,23 @@ class ForecastModule(BaseLightningModule):
             )
             self.loss_coeffs = self.loss_coeffs * self.loss_delta_scaler.pow(self.pow)
 
-        self.metrics = Era5DeterministicMetrics(
-            compute_lat_weights_fn=compute_lat_weights_weatherbench
+        compute_lat_weights_fn = (
+            compute_lat_weights_weatherbench
             if use_weatherbench_lat_coeffs
-            else compute_lat_weights,
-            lead_time_hours=lead_time_hours,
-            rollout_iterations=rollout_iterations,
+            else compute_lat_weights
         )
-
-        # self.test_outputs = []
+        self.train_metrics = nn.ModuleList(
+            [instantiate(metric, **cfg.train.metrics_kwargs) for metric in cfg.train.metrics]
+        )
+        self.val_metrics = nn.ModuleList(
+            [instantiate(metric, **cfg.val.metrics_kwargs) for metric in cfg.val.metrics]
+        )
+        self.test_metrics = nn.ModuleDict(
+            {
+                metric_name: instantiate(metric, **cfg.inference.metrics_kwargs)
+                for metric_name, metric in cfg.inference.metrics.items()
+            }
+        )
 
     def forward(self, batch, *args, **kwargs):
         x = self.embedder.encode(batch["state"], batch.get("prev_state", None))
@@ -166,7 +173,8 @@ class ForecastModule(BaseLightningModule):
 
     def training_step(self, batch, batch_nb):
         denormalize = self.trainer.train_dataloader.dataset.denormalize
-        self.metrics.reset()
+        for metric in self.train_metrics:
+            metric.reset()
 
         if "future_states" not in batch:
             # standard prediction
@@ -174,12 +182,12 @@ class ForecastModule(BaseLightningModule):
             loss = self.loss(pred, batch["next_state"])
             self.mylog(loss=loss)
 
-            self.metrics.update(
-                denormalize(batch["next_state"])[:, None], denormalize(pred)[:, None]
-            )
-            outputs = self.metrics.compute()
-
-            self.mylog(**outputs)
+            for metric in self.train_metrics:
+                metric.update(
+                    denormalize(batch["next_state"])[:, None], denormalize(pred)[:, None]
+                )
+                outputs = metric.compute()
+                self.mylog(**outputs)
 
         else:
             # multistep prediction
@@ -189,43 +197,69 @@ class ForecastModule(BaseLightningModule):
 
             self.mylog(lead_iter=lead_iter)
             self.mylog(loss=loss)
-            # metrics for next state
-            self.metrics.update(
-                denormalize(batch["future_states"][:, :1]), denormalize(pred_future_states[:, :1])
-            )
-            outputs = self.metrics.compute()
-            self.mylog(**outputs)
+            # metrics
+            rollout_iterations = self.cfg.train.metrics_kwargs.rollout_iterations
+            for metric in self.train_metrics:
+                metric.update(
+                    denormalize(batch["future_states"][:, :rollout_iterations]),
+                    denormalize(pred_future_states[:, :rollout_iterations]),
+                )
+                outputs = metric.compute()
+                self.mylog(**outputs)
 
         return loss
 
     def on_validation_epoch_start(self):
-        self.metrics.reset()
+        for metric in self.val_metrics:
+            metric.reset()
 
     def validation_step(self, batch, batch_nb):
-        dataset = self.trainer.val_dataloaders.dataset
-        pred = self.forward(batch)
-        loss = self.loss(pred, batch["next_state"])
-        self.mylog(loss=loss)
+        denormalize = self.trainer.val_dataloaders.dataset.denormalize
 
-        self.metrics.update(
-            dataset.denormalize(batch["next_state"])[:, None], dataset.denormalize(pred)[:, None]
-        )
+        if "future_states" not in batch:
+            # standard prediction
+            pred = self.forward(batch)
+            loss = self.loss(pred, batch["next_state"])
+            self.mylog(loss=loss)
+
+            for metric in self.val_metrics:
+                metric.update(
+                    denormalize(batch["next_state"])[:, None], denormalize(pred)[:, None]
+                )
+
+        else:
+            # multistep prediction
+            lead_iter = batch["future_states"].shape[1]
+            pred_future_states = self.forward_multistep(batch, iters=lead_iter)
+            loss = self.loss(pred_future_states, batch["future_states"], multistep=True)
+
+            self.mylog(lead_iter=lead_iter)
+            self.mylog(loss=loss)
+            # metrics
+            rollout_iterations = self.cfg.val.metrics_kwargs.rollout_iterations
+            for metric in self.val_metrics:
+                metric.update(
+                    denormalize(batch["future_states"][:, :rollout_iterations]),
+                    denormalize(pred_future_states[:, :rollout_iterations]),
+                )
+                outputs = metric.compute()
+                self.mylog(**outputs)
 
         return loss
 
     def on_validation_epoch_end(self):
-        outputs = self.metrics.compute()
-        self.mylog(**outputs, mode="val_")
-        self.metrics.reset()
+        for metric in self.val_metrics:
+            outputs = metric.compute()
+            self.mylog(**outputs, mode="val_")
+            metric.reset()
 
     def on_test_epoch_start(self):
         dataset = self.trainer.test_dataloaders.dataset
-        self.metrics.reset()
+        for metric in self.test_metrics.values():
+            metric.reset()
         Path("evalstore").joinpath(self.name).mkdir(exist_ok=True, parents=True)
         self.test_filename = (
-            Path("evalstore")
-            / self.name
-            / f"{dataset.domain}{self.test_filename_suffix}_metrics.pt"
+            Path("evalstore") / self.name / f"{dataset.domain}{self.test_filename_suffix}"
         )
         if self.save_test_outputs:
             self.zarr_writer = zarr.ZarrIterativeWriter(
@@ -243,10 +277,11 @@ class ForecastModule(BaseLightningModule):
             ref_state = batch["future_states"]
         else:
             ref_state = batch["next_state"][:, None]
-        self.metrics.update(
-            dataset.denormalize(ref_state),
-            dataset.denormalize(preds_future),
-        )
+        for metric in self.test_metrics.values():
+            metric.update(
+                dataset.denormalize(ref_state),
+                dataset.denormalize(preds_future),
+            )
 
         if self.save_test_outputs:
             xr_dataset = dataset.convert_trajectory_to_xarray(
@@ -261,13 +296,17 @@ class ForecastModule(BaseLightningModule):
             self.zarr_writer.to_netcdf(dump_id=batch_nb)
 
     def on_test_epoch_end(self):
-        outputs = self.metrics.compute()
-        torch.save(outputs, self.test_filename)
+        outputs = {}
+        for metric_name, metric in self.test_metrics.items():
+            output = metric.compute()
+            torch.save(output, f"{self.test_filename}_{metric_name}.pt")
+            outputs.update(output)
 
         if self.save_test_outputs:
             self.zarr_writer.to_netcdf(dump_id="final")
 
-        self.metrics.reset()
+        for metric in self.test_metrics.values():
+            metric.reset()
         return outputs
 
     def on_train_epoch_start(self, *args, **kwargs):

--- a/geoarches/lightning_modules/forecast.py
+++ b/geoarches/lightning_modules/forecast.py
@@ -39,6 +39,7 @@ class ForecastModule(BaseLightningModule):
         add_input_state=False,
         save_test_outputs=False,
         use_weatherbench_lat_coeffs=True,
+        lead_time_hours=24,
         rollout_iterations=1,
         test_filename_suffix="",
         **kwargs,
@@ -96,7 +97,7 @@ class ForecastModule(BaseLightningModule):
             compute_lat_weights_fn=compute_lat_weights_weatherbench
             if use_weatherbench_lat_coeffs
             else compute_lat_weights,
-            lead_time_hours=24,
+            lead_time_hours=lead_time_hours,
             rollout_iterations=rollout_iterations,
         )
 

--- a/geoarches/main_hydra.py
+++ b/geoarches/main_hydra.py
@@ -185,8 +185,7 @@ def main(cfg: DictConfig):
             f.write(OmegaConf.to_yaml(cfg, resolve=True))
 
     if cfg.mode == "train":
-        val_args = dict(domain="val")
-        val_args.update(getattr(cfg.dataloader, "validation_args", {}))
+        val_args = getattr(cfg.dataloader, "validation_args", {})
         valset = instantiate(cfg.dataloader.dataset, **val_args)
         trainset = instantiate(cfg.dataloader.dataset)  # will automatically pickup cfg split
 
@@ -206,8 +205,7 @@ def main(cfg: DictConfig):
             collate_fn=collate_fn,
         )
     elif cfg.mode == "test":
-        test_args = dict(domain="test_z0012")
-        test_args.update(getattr(cfg.dataloader, "test_args", {}))
+        test_args = getattr(cfg.dataloader, "test_args", {})
         testset = instantiate(cfg.dataloader.dataset, **test_args)
         test_loader = torch.utils.data.DataLoader(
             testset,
@@ -217,6 +215,8 @@ def main(cfg: DictConfig):
             collate_fn=collate_fn,
         )
 
+    # Resolve interpolations in the entire config before passing `cfg.module`
+    OmegaConf.resolve(cfg.module)
     pl_module = instantiate(cfg.module.module, cfg.module)
 
     if hasattr(cfg, "load_ckpt"):


### PR DESCRIPTION
rollout_iterations:

- explicitly set `rollout_iterations` for train, val, test in module configs
- set dataset `multistep` based on this

lead_time_hours:

- explicitly set in dataset config
- set module `lead_time_hours` based on this for correct metric logging

Ideally though, metrics to log are configurable and the arg lead_time_hours for metric logging is handled separately