### PR TITLE
 Fix timestamp offset in saved output

### DIFF
--- a/geoarches/inference/encode_dataset.py
+++ b/geoarches/inference/encode_dataset.py
@@ -84,9 +84,10 @@ for i, batch in tqdm(enumerate(dl)):
 
     batch = {k: (v.to(device) if hasattr(v, "to") else v) for (k, v) in batch.items()}
     out = module.forward(batch)
-    denorm_out = ds.denormalize(out)
+    out_denorm = ds.denormalize(out)
 
-    xr_list.append(ds.convert_to_xarray(denorm_out, batch["timestamp"]))
+    out_timestamp = batch["timestamp"] + ds.lead_time_hours * 3600  # we predict at t+1
+    xr_list.append(ds.convert_to_xarray(out_denorm, out_timestamp))
 
     if next_year > current_year:
         print("saving file", current_year)


### PR DESCRIPTION
Hey!

I noticed that the saved NetCDF output files produced by `inference.encode_dataset` have timestamps that are consistently off by one timestep compared to the ground truth.

What's happening is that the model’s output corresponds to time `t+1`, but the timestamps coming from the dataloader (and used for saving) correspond to time `t`. This leads to a mismatch between predictions and ground truth, which might affect training or evaluation of models relying on the predictions (e.g., ArchesWeatherGen).

The fix is straightforward which is shifting the timestamps forward by one timestep, according to the dataset `lead_time_hours`.