### PR TITLE
Fix module & cfg loading in encode_dataset.py

### DIFF
--- a/geoarches/inference/encode_dataset.py
+++ b/geoarches/inference/encode_dataset.py
@@ -52,9 +52,11 @@ Path(args.output_path).mkdir(parents=True, exist_ok=True)
 
 
 if len(model_uids) > 1:
-    module, cfg = AvgModule(model_uids).to(device).eval()
+    module = AvgModule(model_uids).to(device).eval()
+    cfg = module.cfg
 else:
-    module, cfg = load_module(model_uids[0]).to(device).eval()
+    module, cfg = load_module(model_uids[0])
+    module.to(device).eval()
 
 
 # create dataset and dataloader

--- a/geoarches/lightning_modules/base_module.py
+++ b/geoarches/lightning_modules/base_module.py
@@ -127,6 +127,12 @@ class AvgModule(L.LightningModule):
 
     def __init__(self, module_paths):
         super().__init__()
+        path = module_paths[0]
+        if Path("modelstore").joinpath(path).exists():
+            path = Path("modelstore").joinpath(path)
+        else:
+            path = Path(path)
+        self.cfg = OmegaConf.load(path / "config.yaml")
         self.core = nn.ModuleList([load_module(p, return_config=False) for p in module_paths])
 
     def forward(self, *args, **kwargs):


### PR DESCRIPTION
In geoarches/inference/encode_dataset.py on line 54 there is a bug.

```
if len(model_uids) > 1:
    module, cfg = AvgModule(model_uids).to(device).eval()
else:
    module, cfg = load_module(model_uids[0]).to(device).eval()
```

If you try to load ensemble of models AvgModule returns only a module. So you get following error:
```
    module, cfg = AvgModule(model_uids).to(device).eval()
    ^^^^^^^^^^^
TypeError: cannot unpack non-iterable AvgModule object
```

on the other hand, if you try to load a single checkpoint load_module returns both module and cfg and `.to(device)` does not work. So you get following error:
```
    module, cfg = load_module(model_uids[0]).to(device).eval()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'tuple' object has no attribute 'to'

```

I added following simple modifications that fixes both issues. This fix assumes that all the ensemble models have the similar config and loads 0th model's config.