### PR TITLE
fix nan masking in loss

### DIFF
--- a/geoarches/dataloaders/netcdf.py
+++ b/geoarches/dataloaders/netcdf.py
@@ -198,8 +198,8 @@ class XarrayDataset(torch.utils.data.Dataset):
         return tdict
 
     def __getitem__(self, i, return_timestamp=False, interpolate_nans=None, warning_on_nan=None):
-        interpolate_nans = interpolate_nans or self.interpolate_nans
-        warning_on_nan = warning_on_nan or self.warning_on_nan
+        interpolate_nans = self.interpolate_nans if interpolate_nans is None else interpolate_nans
+        warning_on_nan = self.warning_on_nan if warning_on_nan is None else warning_on_nan
 
         file_id, line_id, timestamp = self.id2pt[i]
 

--- a/geoarches/lightning_modules/forecast.py
+++ b/geoarches/lightning_modules/forecast.py
@@ -135,8 +135,11 @@ class ForecastModule(BaseLightningModule):
         weighted_error = (pred - gt).abs().pow(self.pow).mul(loss_coeffs)
 
         # Mask loss where gt is NaN.
-        target_valid = tensordict_apply(lambda x: torch.where(torch.isnan(x), 0.0, 1.0), gt)
-        masked_loss = (weighted_error * target_valid) / target_valid.mean()
+        target_valid = tensordict_apply(lambda x: ~torch.isnan(x), gt)
+        weighted_error = tensordict_apply(
+            lambda mask, val: torch.where(mask, val, 0.0), target_valid, weighted_error
+        )
+        masked_loss = (weighted_error) / target_valid.float().mean()
 
         loss = sum(masked_loss.mean().values())
 

--- a/geoarches/lightning_modules/forecast.py
+++ b/geoarches/lightning_modules/forecast.py
@@ -132,16 +132,18 @@ class ForecastModule(BaseLightningModule):
 
             loss_coeffs.apply(lambda x: x * future_coeffs)
 
+        # mask pred to 0 where gt is nan
+        mask = tensordict_apply(lambda g: ~torch.isnan(g), gt)
+        pred = pred * mask
+        
+        # set nans in gt to 0
+        gt = tensordict_apply(lambda g: torch.nan_to_num(g, nan=0.0), gt)
+
         weighted_error = (pred - gt).abs().pow(self.pow).mul(loss_coeffs)
 
-        # Mask loss where gt is NaN.
-        target_valid = tensordict_apply(lambda x: ~torch.isnan(x), gt)
-        weighted_error = tensordict_apply(
-            lambda mask, val: torch.where(mask, val, 0.0), target_valid, weighted_error
-        )
-        masked_loss = (weighted_error) / target_valid.float().mean()
 
-        loss = sum(masked_loss.mean().values())
+        loss = sum(weighted_error.mean().values())
+
 
         return loss
 

--- a/geoarches/lightning_modules/forecast.py
+++ b/geoarches/lightning_modules/forecast.py
@@ -135,15 +135,13 @@ class ForecastModule(BaseLightningModule):
         # mask pred to 0 where gt is nan
         mask = tensordict_apply(lambda g: ~torch.isnan(g), gt)
         pred = pred * mask
-        
+
         # set nans in gt to 0
         gt = tensordict_apply(lambda g: torch.nan_to_num(g, nan=0.0), gt)
 
         weighted_error = (pred - gt).abs().pow(self.pow).mul(loss_coeffs)
 
-
         loss = sum(weighted_error.mean().values())
-
 
         return loss
 

--- a/geoarches/lightning_modules/forecast.py
+++ b/geoarches/lightning_modules/forecast.py
@@ -132,16 +132,15 @@ class ForecastModule(BaseLightningModule):
 
             loss_coeffs.apply(lambda x: x * future_coeffs)
 
-        # mask pred to 0 where gt is nan
+        # Mask loss where gt is NaN.
         mask = tensordict_apply(lambda g: ~torch.isnan(g), gt)
         pred = pred * mask
-
-        # set nans in gt to 0
         gt = tensordict_apply(lambda g: torch.nan_to_num(g, nan=0.0), gt)
 
         weighted_error = (pred - gt).abs().pow(self.pow).mul(loss_coeffs)
+        weighted_error = weighted_error.sum() / mask.sum()
 
-        loss = sum(weighted_error.mean().values())
+        loss = sum(weighted_error.values())
 
         return loss
 

--- a/tests/dataloaders/test_era5.py
+++ b/tests/dataloaders/test_era5.py
@@ -35,6 +35,15 @@ class TestBase:
             level_var_data = np.zeros((len(time), LEVEL, LON, LAT))  # Lon first.
             surface_var_data = np.zeros((len(time), LAT, LON))  # Lat first.
 
+            # Introduce NaNs in the second file (index 1) for all timestamps.
+            if i == 1:
+                level_var_data[:, 0, 0, 0] = np.nan
+                surface_var_data[:, 0, 0] = np.nan
+            # Introduce NaNs in the third file (index 2) for first timestep.
+            if i == 2:
+                level_var_data[0, 0, 0, 0] = np.nan
+                surface_var_data[0, 0, 0] = np.nan
+
             ds = xr.Dataset(
                 data_vars=dict(
                     **{
@@ -362,6 +371,62 @@ class TestEra5Forecast(TestBase):
 
         assert ds.timestamps[0][-1] == expected_start_time
         assert ds.timestamps[-1][-1] == expected_end_time
+
+    def test_interpolate_nans(self):
+        # NaNs are introduced at the first timestamp of the second file (t2).
+        ds = era5.Era5Forecast(
+            stats_cfg=None,
+            path=str(self.test_dir),
+            domain="all",
+            lead_time_hours=6,
+            multistep=1,
+            load_prev=True,
+            load_clim=False,
+            interpolate_nans=True,  # Interpolate NaNs in input (prev_state and state).
+            dimension_indexers={
+                "level": ("level", all_levels),
+                "latitude": ("latitude", slice(None)),
+                "longitude": ("longitude", slice(None)),
+            },
+        )
+
+        # example = ds[0]: prev=t0, state=t1, next=t2.
+        # t2 has NaNs. Since interpolate_nans is True, prev_state and state are interpolated,
+        # but next_state is not. So, next_state should contain NaNs.
+        example0 = ds[0]
+        assert not np.isnan(example0["prev_state"]["level"].numpy()).any()
+        assert not np.isnan(example0["prev_state"]["surface"].numpy()).any()
+        assert not np.isnan(example0["state"]["level"].numpy()).any()
+        assert not np.isnan(example0["state"]["surface"].numpy()).any()
+        # next_state should have NaNs.
+        assert np.isnan(example0["next_state"]["level"].numpy()).any()
+        assert np.isnan(example0["next_state"]["surface"].numpy()).any()
+
+        # example = ds[1]: prev=t1, state=t2, next=t3.
+        # t2 and t3 has NaNs. Since interpolate_nans is True, state should be interpolated.
+        example1 = ds[1]
+        assert not np.isnan(example1["prev_state"]["level"].numpy()).any()
+        assert not np.isnan(example1["prev_state"]["surface"].numpy()).any()
+        # state has NaNs originally, but should be interpolated.
+        assert not np.isnan(example1["state"]["level"].numpy()).any()
+        assert not np.isnan(example1["state"]["surface"].numpy()).any()
+        # next_state should have NaNs.
+        assert np.isnan(example1["next_state"]["level"].numpy()).any()
+        assert np.isnan(example1["next_state"]["surface"].numpy()).any()
+
+        # example = ds[2]: prev=t2, state=t3, next=t4.
+        # t2, t3 and t4 has NaNs. Since interpolate_nans is True,
+        # # prev_state and state should be interpolated.
+        example1 = ds[2]
+        # prev_state has NaNs originally, but should be interpolated.
+        assert not np.isnan(example1["prev_state"]["level"].numpy()).any()
+        assert not np.isnan(example1["prev_state"]["surface"].numpy()).any()
+        # state has NaNs originally, but should be interpolated.
+        assert not np.isnan(example1["state"]["level"].numpy()).any()
+        assert not np.isnan(example1["state"]["surface"].numpy()).any()
+        # next_state should have NaNs.
+        assert np.isnan(example1["next_state"]["level"].numpy()).any()
+        assert np.isnan(example1["next_state"]["surface"].numpy()).any()
 
 
 class TestEra5ForecastWithGraphcastNormalization(TestBase):

--- a/tests/lightning_modules/test_forecast.py
+++ b/tests/lightning_modules/test_forecast.py
@@ -1,0 +1,68 @@
+import torch
+from tensordict.tensordict import TensorDict
+
+from geoarches.lightning_modules.forecast import ForecastModule
+
+
+class TestForecastModule:
+    class DummyStats:
+        def __init__(self):
+            self.variables = {"level": ["var1"], "surface": ["var2"]}
+            self.levels = [500]
+
+        def compute_loss_coeffs(self):
+            # Return loss coeffs of 1 for all variables
+            level_coeffs = torch.ones(1, 1, 1, 1)
+            surface_coeffs = torch.ones(1, 1, 1)
+            return TensorDict({"level": level_coeffs, "surface": surface_coeffs}, batch_size=[])
+
+    class DummyCfg:
+        def __init__(self):
+            self.compute_loss_coeffs_args = {}
+            self.train = self
+            self.val = self
+            self.inference = self
+            self.metrics = {}  # Should be a dict, not a list
+            self.metrics_kwargs = {}
+
+    def test_loss_with_nans_in_gt(self):
+        # Create a dummy ForecastModule
+        stats_cfg = self.DummyCfg()
+        # To make DummyStats instantiable by Hydra, wrap it in a dict with _target_
+        stats_cfg.module = {"_target_": self.DummyStats}
+        module_cfg = self.DummyCfg()
+        module_cfg.backbone = None
+        module_cfg.embedder = None
+        forecast_module = ForecastModule(
+            cfg=module_cfg,
+            stats_cfg=stats_cfg,
+        )
+        # The loss_coeffs will be computed within ForecastModule.__init__
+        # using the instantiated self.DummyStats.
+        forecast_module.to("cpu")
+
+        # Create dummy pred and gt tensordicts
+        pred = TensorDict(
+            {
+                "level": torch.zeros(1, 1, 2, 2),
+                "surface": torch.zeros(1, 1, 2, 2),
+            },
+            batch_size=[],
+        )
+
+        # Create gt with NaNs
+        gt = TensorDict(
+            {
+                "level": torch.randn(1, 1, 2, 2),
+                "surface": torch.randn(1, 1, 2, 2),
+            },
+            batch_size=[],
+        )
+        gt["level"][0, 0, 0, 0] = torch.nan
+        gt["surface"][0, 0, 0, 0] = torch.nan
+
+        # Compute loss
+        loss = forecast_module.loss(pred, gt)
+
+        # Assert that the loss is not NaN
+        assert not torch.isnan(loss)

--- a/tests/lightning_modules/test_forecast.py
+++ b/tests/lightning_modules/test_forecast.py
@@ -41,7 +41,6 @@ class TestForecastModule:
         # using the instantiated self.DummyStats.
         forecast_module.to("cpu")
 
-        # Create dummy pred and gt tensordicts
         pred = TensorDict(
             {
                 "level": torch.zeros(1, 1, 2, 2),
@@ -50,7 +49,7 @@ class TestForecastModule:
             batch_size=[],
         )
 
-        # Create gt with NaNs
+        # Create gt with NaNs.
         gt = TensorDict(
             {
                 "level": torch.randn(1, 1, 2, 2),
@@ -61,8 +60,6 @@ class TestForecastModule:
         gt["level"][0, 0, 0, 0] = torch.nan
         gt["surface"][0, 0, 0, 0] = torch.nan
 
-        # Compute loss
         loss = forecast_module.loss(pred, gt)
 
-        # Assert that the loss is not NaN
         assert not torch.isnan(loss)


### PR DESCRIPTION
Two issues:
- Dataloader was never leaving nans in gt because `interpolate_nans` was always set to True based on `self.interpolate_nans`
- Loss multiplied nan by mask which does not get rid of nan, need to explicitly replace with torch.where