### PR TITLE
Add input data parameter to the encode_dataset.py

### DIFF
--- a/geoarches/inference/encode_dataset.py
+++ b/geoarches/inference/encode_dataset.py
@@ -34,7 +34,9 @@ parser.add_argument(
     type=str,
     help="Comma separated list of model uids, names of checkpoint folders stored under `modelstore/` dir.",
 )
-parser.add_argument("--input-path", default="data/era5_240/full/", help="where to load inputs from")
+parser.add_argument(
+    "--input-path", default="data/era5_240/full/", help="where to load inputs from"
+)
 
 
 args = parser.parse_args()


### PR DESCRIPTION
Hi! Needed to follow [docs](https://geoarches.readthedocs.io/en/latest/archesweather/train/#step-3-training-archesweathergen) couple of times and noticed that input data path was hardcoded as `data/era5_240/full/`. Would be helpful to have as an argument.